### PR TITLE
Add interfaceID constant

### DIFF
--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
@@ -20,6 +20,13 @@ public final class EntryExtraData {
     public static final String PARAM_PACKAGE = "senderPackage";
 
     /**
+     * Interface Identifier
+     * Interface: Instance of a UI Entry Action
+     * <p>Type: int</p>
+     */
+    public static final String PARAM_INTERFACE_ID = "interfaceID";
+
+    /**
      * Transaction Type
      * <p>Type : String</p>
      * <p>Example: "CREDIT SALE"</p>

--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryResponse.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryResponse.java
@@ -30,14 +30,6 @@ public final class EntryResponse {
     /**
      * Result Code
      * <p>Type: Long</p>
-     * <p>
-     *     -201	Errors involving data format issues, e.g.: data length error, date format error, etc.<br>
-     *     -202	Data Content Error: data format is correct, but contents are invalid and the user needs to re-enter the data.<br>
-     *     -203	Timeout: the input action exceeds the timeout.<br>
-     *     -204	Protocol Error: Customized UI requested incorrect data from BroadPOS<br>
-     *     -205	Index Error: Customized UI requested an incorrect index from BroadPOS<br>
-     *     -206	Security Area Error: Customized UI requested incorrect security area from BroadPOS<br>
-     * </p>
      */
     public static final String PARAM_CODE = "resultCode";
 


### PR DESCRIPTION
Every interface initiated by BroadPOS for the UI App will bundle an ID.
This ID will later be used to track the response broadcast (ACCEPTED, DECLINED).
