### PR TITLE
Revert "[POSUI-102] UI Entry Action defined as 'ENTER_ADMINISTRATOR_PASSWORD' is defined in the SDK as 'com.pax.us.pay.action.ADMINISTRATOR_PASSWORD'."

### DIFF
--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/SecurityEntry.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/SecurityEntry.java
@@ -552,7 +552,7 @@ public final class SecurityEntry {
      *     About how to send output to BroadPOS, see {@link EntryRequest#ACTION_SECURITY_AREA} for details.<br>
      * </p>
      */
-    public static final String ACTION_ENTER_ADMINISTRATION_PASSWORD = "com.pax.us.pay.action.ENTER_ADMINISTRATOR_PASSWORD";
+    public static final String ACTION_ENTER_ADMINISTRATION_PASSWORD = "com.pax.us.pay.action.ADMINISTRATOR_PASSWORD";
 
     /**
      * Activity Action: Manage Input Account<br>{@value #ACTION_MANAGE_INPUT_ACCOUNT}<br>


### PR DESCRIPTION
Reverts PAXTechnologyInc/POSLink-UI#86 because ticket is rejected.

https://pax-us.atlassian.net/browse/POSUI-102