### PR TITLE
[ANJPXU-137][ANBP-1652][BPOSANDJAX-1489] Showitem doesn't show latter items when Topdown set to N (bottom up).

### DIFF
--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
@@ -950,6 +950,16 @@ public final class EntryExtraData {
      * <p>Type: String[]</p>
      */
     public static final String PARAM_MESSAGE_LIST = "messageList";
+
+    /**
+     * Top Down
+     * <p>Type: Boolean <br>
+     * Text pushed in top down or bottom up.<br>
+     * True is top down. False is bottom up</p>
+     * <p>Default is true</p>
+     */
+    public static final String PARAM_TOP_DOWN = "topDown";
+
     /**
      * Currency Symbol
      * <p>Type: String</p>

--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/PoslinkEntry.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/PoslinkEntry.java
@@ -245,6 +245,12 @@ public final class PoslinkEntry {
      *     Type: String<br>
      *     Value is always {@value com.pax.us.pay.ui.constant.entry.enumeration.ManageUIConst.ContinuousScreen#DO_NOT_GO_TO_IDLE}
      * </p>
+     * <p>
+     *     Input: {@link EntryExtraData#PARAM_TOP_DOWN}  - {@value EntryExtraData#PARAM_TOP_DOWN}<br>
+     *     Type: Boolean<br>
+     *     Text pushed in top down or bottom up.<br>
+     *     True is top down. False is bottom up. Default is True.
+     * </p>
      */
     public static final String ACTION_SHOW_MESSAGE = "com.pax.us.pay.action.SHOW_MESSAGE";
 
@@ -279,6 +285,12 @@ public final class PoslinkEntry {
      * <p>
      *     Input: {@link EntryExtraData#PARAM_MESSAGE_LIST}  - {@value EntryExtraData#PARAM_MESSAGE_LIST}<br>
      *     Type: String
+     * </p>
+     * <p>
+     *     Input: {@link EntryExtraData#PARAM_TOP_DOWN}  - {@value EntryExtraData#PARAM_TOP_DOWN}<br>
+     *     Type: Boolean<br>
+     *     Text pushed in top down or bottom up.<br>
+     *     True is top down. False is bottom up. Default is True.
      * </p>
      */
     public static final String ACTION_SHOW_ITEM = "com.pax.us.pay.action.SHOW_ITEM";


### PR DESCRIPTION
# JIRA Ticket
1.https://pax-us.atlassian.net/browse/BPOSANDJAX-1489
2.https://pax-us.atlassian.net/browse/ANJPXU-137
3.https://pax-us.atlassian.net/browse/ANBP-1652


# How to Fix
<img width="562" alt="image" src="https://github.com/PAXTechnologyInc/POSLink-UI/assets/47148646/f00b3fc1-2094-417d-afaa-ca06a4426ab0">

To fix the CASE 2,
Added a boolean parameter to control if ShowItem/ShowMessage need show the first page or last page of items.
