### PR TITLE
[POSUI-289] POSLink UI demo only support YYYY/MM/DD format for Original Transaction Date Causing 'ORIG DATE TOO LONG,INPUT AGAIN' error

### DIFF
--- a/lib-ui-constant/build.gradle
+++ b/lib-ui-constant/build.gradle
@@ -20,3 +20,12 @@ targetCompatibility = "7"
 if(rootProject.name == "POSLinkUI") {
     apply from: file('../gradle/publish.gradle')
 }
+
+jar {
+    manifest {
+        attributes(
+                'Implementation-Title': 'POSLinkUI',
+                'Implementation-Version': version
+        )
+    }
+}

--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryExtraData.java
@@ -1131,4 +1131,7 @@ public final class EntryExtraData {
 //    * */
 //    public static final String PARAM_INTERNAL_NICKNAME_FLAG = "internalNicknameFlag";
 
+
+    public static final String PARAM_DATE_FORMAT = "dateFormat";
+
 }

--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/enumeration/DateFormat.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/enumeration/DateFormat.java
@@ -1,0 +1,21 @@
+package com.pax.us.pay.ui.constant.entry.enumeration;
+
+public final class DateFormat {
+    private DateFormat(){
+    }
+
+    public static final String MMYY = "MMYY";
+
+    public static final String MMDD = "MMDD";
+
+    public static final String YYYYMMDD = "YYYYMMDD";
+
+    /**
+     * All defined String
+     * @return String[]
+     */
+    public static String[] values() {
+        return new String[]{MMYY, MMDD, YYYYMMDD};
+    }
+
+}


### PR DESCRIPTION
Added Date Format param and enum.