### PR TITLE
[POSUI-284] POSLink UI Demo sending the same EntryRequest.ACTION_NEXT broadcast irrespective of whether the 'Confirm' or 'No Tip' button is selected

### DIFF
--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryRequest.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/EntryRequest.java
@@ -263,6 +263,8 @@ public final class EntryRequest {
     /**
      * Tip Amount
      * <p>Type: Long</p>
+     * <p>Submitting PARAM_TIP=0L will mark the transaction Untipped.</p>
+     * <p>To indicate the "No Tip" option is selected, UI App needs to remove this parameter from the submission bundle.</p>
      */
     public static final String PARAM_TIP = "tip";
 

--- a/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/TextEntry.java
+++ b/lib-ui-constant/src/main/java/com/pax/us/pay/ui/constant/entry/TextEntry.java
@@ -92,14 +92,16 @@ public final class TextEntry {
      * <p>
      *     Example:<br>
      *     if value of {@link EntryExtraData#PARAM_TIP_OPTIONS} is {"300","500","700"}, <br>
-     *     you could provide 3 options for user:<br><br>
-     *     $3.00, $5.00, $7.00
+     *     you could provide 3 options for user:$3.00, $5.00, $7.00. <br>
+     *     The array contains String that can be converted to Long.<br>
      * </p>
      * <p>
      *     Input: {@link EntryExtraData#PARAM_TIP_RATE_OPTIONS} - {@value EntryExtraData#PARAM_TIP_RATE_OPTIONS} is tip percentage options.<br>
      *     Type: String[]<br>
      *     It is optional. Used when tip select is enabled.<br>
      *     Used with {@link EntryExtraData#PARAM_TIP_OPTIONS} together.<br>
+     *     It has the same size as the value of {@link EntryExtraData#PARAM_TIP_OPTIONS}<br>
+     *     And it contains additional information (rate in percentage) for each option in {@link EntryExtraData#PARAM_TIP_OPTIONS}<br>
      * </p>
      * <p>
      *     Example:<br>
@@ -151,8 +153,8 @@ public final class TextEntry {
      *     Output: {@link EntryRequest#PARAM_TIP} - {@value EntryRequest#PARAM_TIP}<br>
      *     Type: Long<br>
      *     Optional. <br>
-     *     If return nothing, BroadPOS will treat it as tip bypassed.<br>
-     *     If return 0, BroadPOS will treat it as "NO TIP"<br>
+     *     To indicate that "NO TIP" has been selected, {@link EntryRequest#PARAM_TIP} needs to be absent in the output extras.<br>
+     *     If {@link EntryRequest#PARAM_TIP} is set to zero, BroadPOS will treat it as an untipped transaction.<br>
      * </p>
      */
     public static final String ACTION_ENTER_TIP = "com.pax.us.pay.action.ENTER_TIP";


### PR DESCRIPTION
Added description for ACTION_ENTER_TIP.